### PR TITLE
fix: exclude /api routes from SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "framework": "vite",
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!api).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## Issue

Without this fix,  requests were being rewritten to , preventing the serverless function from handling them.

## Changes

- Add negative lookahead `(?!api)` to the rewrite pattern in `vercel.json`
- Pattern now: `/((?!api).*)` instead of `/(.*)`

## How It Works

**Before:**
```
/api/branches → rewritten to /index.html ❌
```

**After:**
```
/api/branches → routed to api/[...path].ts ✅
/          → rewritten to /index.html ✅
/branches    → rewritten to /index.html ✅
```

## Testing

- ✅ SPA routing still works (all non-api routes go to index.html)
- ✅ API routes properly reach serverless function
- ✅ No conflicts with Vercel catch-all `api/[...path].ts`

## Related

This complements PR #8 (API proxy routing fix)